### PR TITLE
run google signin code on the server instead of client

### DIFF
--- a/pages/auth/google/callback.js
+++ b/pages/auth/google/callback.js
@@ -1,64 +1,9 @@
 import { axiosInstance } from "@/components/utils/axios";
 import axios from "axios";
 import Head from "next/head";
-import { useRouter } from "next/router";
-import React, { useEffect, useState } from "react";
-import { useMutation } from "react-query";
+import React from "react";
 
 const Callback = () => {
-  const router = useRouter();
-  const [code, setCode] = useState("");
-
-  const { mutate: mutateLogin } = useMutation(
-    async ({ accessToken, code, idToken }) =>
-      await axiosInstance.post("/accounts/google/", {
-        access_token: idToken,
-        code: code,
-        id_token: accessToken,
-      }),
-    {
-      onError: () => {
-        router.push("/404");
-      },
-      onSuccess: () => {
-        router.push("/");
-      },
-    }
-  );
-
-  const { mutate: mutateToken } = useMutation(
-    async ({ postCode }) =>
-      await axios.post(
-        "https://oauth2.googleapis.com/token",
-        `code=${postCode}&client_id=${process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID}&client_secret=${process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_SECRET}&redirect_uri=${process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CALLBACK_URL}&grant_type=authorization_code`,
-
-        {
-          Headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-          },
-        }
-      ),
-    {
-      onError: () => {
-        router.push("/404");
-      },
-      onSuccess: data => {
-        mutateLogin({
-          accessToken: data.data.access_token,
-          code: code,
-          idToken: data.data.id_token,
-        });
-      },
-    }
-  );
-
-  useEffect(() => {
-    const { query } = router;
-    if (query && query.code) {
-      setCode(query.code);
-      mutateToken({ postCode: query.code });
-    }
-  }, [router.query]);
   return (
     <>
       <Head>
@@ -70,3 +15,39 @@ const Callback = () => {
 };
 
 export default Callback;
+
+export async function getServerSideProps({ query, res }) {
+  try {
+    const code = query.code;
+    const googleResponse = await axios.post(
+      "https://oauth2.googleapis.com/token",
+      `code=${code}&client_id=${process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID}&client_secret=${process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_SECRET}&redirect_uri=${process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CALLBACK_URL}&grant_type=authorization_code`,
+      {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+      }
+    );
+
+    const postResponse = await axiosInstance.post("/accounts/google/", {
+      access_token: googleResponse.data.id_token,
+      code: code,
+      id_token: googleResponse.data.access_token,
+    });
+    res.setHeader("Set-Cookie", postResponse.headers["set-cookie"]);
+
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  } catch (error) {
+    return {
+      redirect: {
+        destination: "/404",
+        permanent: false,
+      },
+    };
+  }
+}


### PR DESCRIPTION
This change means generating users' google id_token, access_token and signing them on the backend is done on the server instead of the client. Making it more secure and less vulnerable to attack.